### PR TITLE
Use `LambdaVM` instead of `VMTropy` after rename

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,6 @@ jobs:
     runs-on: [self-hosted, nomad]
     steps:
       - uses: actions/checkout@v2
-      - uses: webfactory/ssh-agent@v0.7.0
-        with:
-          ssh-private-key: ${{ secrets.GH_SSH_PRIVATE_KEY }}
       - uses: actions-rs/toolchain@v1
         with:
             toolchain: nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,9 +61,9 @@ sha3 = "0.10.6"
 cfg-if = "1"
 serial_test = "*"
 
-[dependencies.vmtropy]
+[dependencies.lambdavm]
 git = "ssh://git@github.com/lambdaclass/aleo_lambda_vm.git"
-branch = "main"
+branch = "rename-crate"
 optional = true
 
 [dependencies.snarkvm]
@@ -80,6 +80,6 @@ ctor = "0.1.23"
 
 [features]
 default = ["snarkvm_backend"]
-#default = ["vmtropy_backend"]
+#default = ["lambdavm_backend"]
 snarkvm_backend = ["snarkvm"]
-vmtropy_backend =  ["vmtropy"]
+lambdavm_backend =  ["lambdavm"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,12 +74,13 @@ optional = true
 
 [dev-dependencies]
 assert_fs = "1.0.9"
+snarkvm = { git = "https://github.com/Lambdaclass/snarkVM.git", branch = "entropy_fork" } # used for creating records in tests
 assert_cmd = "2.0.6"
 retry = "2.0.0"
 ctor = "0.1.23"
 
 [features]
-default = ["snarkvm_backend"]
 #default = ["lambdavm_backend"]
+#default = ["snarkvm_backend"]
 snarkvm_backend = ["snarkvm"]
 lambdavm_backend =  ["lambdavm"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ serial_test = "*"
 
 [dependencies.lambdavm]
 git = "ssh://git@github.com/lambdaclass/aleo_lambda_vm.git"
-branch = "rename-crate"
+branch = "main"
 optional = true
 
 [dependencies.snarkvm]

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ ARCH=amd64
 endif
 
 TENDERMINT_HOME=~/.tendermint/
-VM_FEATURE=snarkvm_backend
+VM_FEATURE ?= lambdavm_backend
 
 # Build the client program and put it in bin/aleo
 cli:
@@ -102,7 +102,6 @@ abci:
 	cargo run --release --bin snarkvm_abci  --features $(VM_FEATURE)
 
 # run tests on release mode (default VM backend) to ensure there is no extra printing to stdout
-test: FEATURE:=snarkvm_abci
 test:
 	RUST_BACKTRACE=full cargo test --release --features $(VM_FEATURE) -- --nocapture --test-threads=4
 

--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,11 @@ ARCH=amd64
 endif
 
 TENDERMINT_HOME=~/.tendermint/
+VM_FEATURE=snarkvm_backend
 
 # Build the client program and put it in bin/aleo
 cli:
-	mkdir -p bin && cargo build --release && cp target/release/client bin/aleo
+	mkdir -p bin && cargo build --release --features $(VM_FEATURE) && cp target/release/client bin/aleo
 
 # Installs tendermint for current OS and puts it in bin/
 bin/tendermint:
@@ -29,7 +30,7 @@ tendermint_install:
 genesis: bin/tendermint cli
 	test -f $(TENDERMINT_HOME)/account.json || ALEO_HOME=$(TENDERMINT_HOME) bin/aleo account new
 	bin/tendermint init
-	cargo run --bin genesis --release -- $(TENDERMINT_HOME)
+	cargo run --bin genesis --release --features $(VM_FEATURE) -- $(TENDERMINT_HOME)
 
 # Run a tendermint node, installing it if necessary
 node: genesis tendermint_config
@@ -52,7 +53,7 @@ testnet: bin/tendermint cli
 	  ALEO_HOME=$$node bin/aleo account new ; \
           make tendermint_config TENDERMINT_HOME=$$node ; \
 	done
-	cargo run --bin genesis --release -- $(HOMEDIR)/*
+	cargo run --bin genesis --release --features $(VM_FEATURE) -- $(HOMEDIR)/*
 
 # Initialize the tendermint configuration for a localnet of the given amount of validators
 localnet: VALIDATORS:=4
@@ -66,7 +67,7 @@ localnet: bin/tendermint cli
         make localnet_config TENDERMINT_HOME=$(HOMEDIR)/node$$n NODE=$$n VALIDATORS=$(VALIDATORS); \
 		mkdir $(HOMEDIR)/node$$n/abci ; \
 	done
-	cargo run --bin genesis --release -- $(HOMEDIR)/*
+	cargo run --bin genesis --release --features $(VM_FEATURE) -- $(HOMEDIR)/*
 .PHONY: localnet
 
 localnet_config:
@@ -86,7 +87,7 @@ localnet_start: NODE:=0
 localnet_start: HOMEDIR:=localnet
 localnet_start:
 	bin/tendermint node --home ./$(HOMEDIR)/node$(NODE) --consensus.create_empty_blocks_interval="90s" &
-	cd ./$(HOMEDIR)/node$(NODE)/abci; cargo run --release --bin snarkvm_abci -- --port 26$(NODE)58
+	cd ./$(HOMEDIR)/node$(NODE)/abci; cargo run --release --bin snarkvm_abci --features $(VM_FEATURE) -- --port 26$(NODE)58
 .PHONY: localnet_start
 
 # remove the blockchain data
@@ -98,11 +99,13 @@ reset: bin/tendermint
 
 # run the snarkvm tendermint application
 abci:
-	cargo run --release --bin snarkvm_abci
+	cargo run --release --bin snarkvm_abci  --features $(VM_FEATURE)
 
-# run tests on release mode to ensure there is no extra printing to stdout
+# run tests on release mode (default VM backend) to ensure there is no extra printing to stdout
+test: FEATURE:=snarkvm_abci
 test:
-	RUST_BACKTRACE=full cargo test --release -- --nocapture --test-threads=4
+	RUST_BACKTRACE=full cargo test --release --features $(VM_FEATURE) -- --nocapture --test-threads=4
+
 
 dockernet-build-abci:
 	docker build -t snarkvm_abci .

--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@ The consensus/blockchain engine has been built with [Tendermint Core](https://do
 
 ## Table of Contents  
 
-- [Aleo-Lambda Blockchain](#aleo-lambda-blockchain)
+- [Aleo Lambda Blockchain](#aleo-lambda-blockchain)
   - [Project structure](#project-structure)
   - [Example application usage](#example-application-usage)
     - [Sending programs and executions to the blockchain](#sending-programs-and-executions-to-the-blockchain)
+    - [Changing the VM backend](#changing-the-vm-backend)
   - [Other features](#other-features)
     - [Debugging the client/ABCI](#debugging-the-clientabci)
     - [Setting the blockchain endpoint](#setting-the-blockchain-endpoint)
@@ -181,6 +182,26 @@ make reset
 ```
 
 to restore the initial state. Notice that this will delete the databases that store the programs and the records, so previous deployments and account records will be deleted.
+
+### Changing the VM backend
+
+By default, LambdaVM is enabled on the project. In order to change it, you can export/set `VM_BACKEND` or pass it to the `make` commands with `-e`. The following options are valid:
+
+- `snarkvm_backend`: SnarkVM implementation
+- `lambdavm_backend`: Our own Aleo VM implementation (set by default)
+
+Note that because all Rust binaries use the VM, the same backend needs to be set for all of them. Because the blockchain persists data (such as program verifying keys) on disk, it is necessary to run `make reset` as described above before swapping the VM backend. The following example is a valid way to set the backend and start the network.
+
+````sh
+make reset #erases persisted data that might be related to the previously-set backend
+export VM_FEATURE=snarkvm_backend
+make cli #compiles the CLI
+make abci #starts the ABCI
+make node #(on another terminal) start the Tendermint binary
+````
+
+After this, you can run CLI commands appropriately. 
+All other examples in this README can be executed with either backend by setting the correct environment variable. 
 
 ## Other features
 

--- a/README.md
+++ b/README.md
@@ -190,10 +190,11 @@ By default, LambdaVM is enabled on the project. In order to change it, you can e
 - `snarkvm_backend`: SnarkVM implementation
 - `lambdavm_backend`: Our own Aleo VM implementation (set by default)
 
-Note that because all Rust binaries use the VM, the same backend needs to be set for all of them. Because the blockchain persists data (such as program verifying keys) on disk, it is necessary to run `make reset` as described above before swapping the VM backend. The following example is a valid way to set the backend and start the network.
+Note that because all Rust binaries use the VM, the same backend needs to be set for all of them. Because the blockchain persists data (such as program verifying keys and record-related data) on disk, it is necessary to run `make reset` as described above before swapping the VM backend. Furthermore, the `credits` program's keys are cached on disk in the directory `~/.aleo/cache`, so you need to remove this directory because verifying keys are not compatible across the VM backends.  The following example is a valid way to set the backend and start the network.
 
 ````sh
-make reset #erases persisted data that might be related to the previously-set backend
+make reset #erases blockchain-related persisted data (records and deployed programs) that might be related to the previously-set backend
+rm -rf ~/.aleo/cache #remove cached credits program used by CLI and blockchain
 export VM_FEATURE=snarkvm_backend
 make cli #compiles the CLI
 make abci #starts the ABCI

--- a/src/blockchain/application.rs
+++ b/src/blockchain/application.rs
@@ -540,7 +540,7 @@ mod tests {
 
         let transaction_json = json!(transaction);
 
-        #[cfg(feature = "vmtropy_backend")]
+        #[cfg(feature = "lambdavm_backend")]
         let pointer_path = "/Execution/transitions/0/outputs/0/EncryptedRecord/1/ciphertext";
         #[cfg(feature = "snarkvm_backend")]
         let pointer_path = "/Execution/transitions/0/outputs/0/value";

--- a/src/blockchain/record_store.rs
+++ b/src/blockchain/record_store.rs
@@ -180,7 +180,7 @@ impl RecordStore {
     }
 
     /// Saves a new unspent record to the write buffer
-    #[allow(clippy::redundant_clone)] // commitments/serial numbers are strings on VMTropy and so clippy generates a warning for `.to_string()`
+    #[allow(clippy::redundant_clone)] // commitments/serial numbers are strings on lambdavm and so clippy generates a warning for `.to_string()`
     pub fn add(&self, commitment: Commitment, record: vm::EncryptedRecord) -> Result<()> {
         let (reply_sender, reply_receiver) = sync_channel(0);
 
@@ -219,7 +219,7 @@ impl RecordStore {
     }
 
     /// Return up to `limit` record ciphertexts
-    #[allow(clippy::redundant_clone)] // commitments/serial numbers are strings on VMTropy and so clippy generates a warning for `.to_string()`
+    #[allow(clippy::redundant_clone)] // commitments/serial numbers are strings on lambdavm and so clippy generates a warning for `.to_string()`
     pub fn scan(&self, from: Option<SerialNumber>, limit: Option<usize>) -> Result<ScanResult> {
         let from = from.map(|commitment| commitment.to_string().into_bytes());
         let (reply_sender, reply_receiver) = sync_channel(0);
@@ -418,9 +418,9 @@ mod tests {
 
     // TODO: (check if it's possible) make a test for validating behavior related to spending a non-existant record
 
-    #[cfg(feature = "vmtropy_backend")]
+    #[cfg(feature = "lambdavm_backend")]
     fn new_record() -> (EncryptedRecord, Commitment, SerialNumber) {
-        use vmtropy::snarkvm::prelude::{Scalar, Uniform};
+        use lambdavm::snarkvm::prelude::{Scalar, Uniform};
 
         let address =
             String::from("aleo1330ghze6tqvc0s9vd43mnetxlnyfypgf6rw597gn4723lp2wt5gqfk09ry");

--- a/src/blockchain/record_store.rs
+++ b/src/blockchain/record_store.rs
@@ -420,7 +420,7 @@ mod tests {
 
     #[cfg(feature = "lambdavm_backend")]
     fn new_record() -> (EncryptedRecord, Commitment, SerialNumber) {
-        use lambdavm::snarkvm::prelude::{Scalar, Uniform};
+        use snarkvm::prelude::{Scalar, Uniform};
 
         let address =
             String::from("aleo1330ghze6tqvc0s9vd43mnetxlnyfypgf6rw597gn4723lp2wt5gqfk09ry");

--- a/src/blockchain/validator_set.rs
+++ b/src/blockchain/validator_set.rs
@@ -648,7 +648,7 @@ mod tests {
                 let decrypted = record.decrypt(&owner.0).unwrap();
                 #[cfg(feature = "snarkvm_backend")]
                 let gates = ***decrypted.gates();
-                #[cfg(feature = "vmtropy_backend")]
+                #[cfg(feature = "lambdavm_backend")]
                 let gates = decrypted.gates;
                 acc + gates
             })

--- a/src/client/commands.rs
+++ b/src/client/commands.rs
@@ -193,7 +193,7 @@ impl Command {
                         |acc, (_, _, record)| {
                             #[cfg(feature = "snarkvm_backend")]
                             let gates = ***record.gates();
-                            #[cfg(feature = "vmtropy_backend")]
+                            #[cfg(feature = "lambdavm_backend")]
                             let gates = record.gates;
                             acc + gates
                         },
@@ -541,7 +541,7 @@ fn select_default_fee_record(
         .sorted_by_key(|record| {
             #[cfg(feature = "snarkvm_backend")]
             let gates = ***record.gates();
-            #[cfg(feature = "vmtropy_backend")]
+            #[cfg(feature = "lambdavm_backend")]
             let gates = record.gates;
 
             // negate to get bigger records first
@@ -550,7 +550,7 @@ fn select_default_fee_record(
         .find(|record| {
             #[cfg(feature = "snarkvm_backend")]
             let gates = ***record.gates();
-            #[cfg(feature = "vmtropy_backend")]
+            #[cfg(feature = "lambdavm_backend")]
             let gates = record.gates;
             // note that here we require that the amount of the record be more than the requested fee
             // even though there may be implicit fees in the execution that make the actual amount to be subtracted

--- a/src/lib/transaction.rs
+++ b/src/lib/transaction.rs
@@ -119,7 +119,7 @@ impl Transaction {
             .map(|(commitment, record)| (*commitment, record.clone()))
             .collect();
 
-        #[cfg(feature = "vmtropy_backend")]
+        #[cfg(feature = "lambdavm_backend")]
         return self
             .transitions()
             .iter()
@@ -137,7 +137,7 @@ impl Transaction {
             .flat_map(|transition| transition.serial_numbers().copied())
             .collect();
 
-        #[cfg(feature = "vmtropy_backend")]
+        #[cfg(feature = "lambdavm_backend")]
         return self
             .transitions()
             .iter()
@@ -235,7 +235,7 @@ impl Transaction {
             }
 
             let gates = gates as i64 - implicit_fee;
-            #[cfg(feature = "vmtropy_backend")]
+            #[cfg(feature = "lambdavm_backend")]
             let inputs = [
                 vm::UserInputValueType::Record(crate::vm::Record {
                     owner: record.owner,
@@ -324,8 +324,8 @@ impl Transaction {
                     hasher.update(key.to_string());
                     #[cfg(feature = "snarkvm_backend")]
                     let serialization = serde_json::to_string(&value)?;
-                    #[cfg(feature = "vmtropy_backend")]
-                    let serialization = vmtropy::serialize_verifying_key(value)?;
+                    #[cfg(feature = "lambdavm_backend")]
+                    let serialization = lambdavm::serialize_verifying_key(value)?;
                     hasher.update(serialization);
                 }
 

--- a/src/lib/vm/lambdavm/mod.rs
+++ b/src/lib/vm/lambdavm/mod.rs
@@ -6,7 +6,6 @@ use anyhow::{anyhow, bail, ensure, Result};
 pub use lambdavm::build_program;
 pub use lambdavm::jaleo::{get_credits_key, mint_credits};
 pub use lambdavm::jaleo::{Itertools, UserInputValueType};
-use lambdavm::snarkvm::prelude::FromBytes;
 use lambdavm::VariableType;
 use log::debug;
 use sha3::{Digest, Sha3_256};
@@ -279,12 +278,14 @@ where
 // same as above
 pub fn address_from_output(output: &VariableType) -> Result<Address> {
     if let VariableType::Public(UserInputValueType::Address(address)) = output {
-        let address = Address::from_bytes_le(address)?;
+        let address_string = std::str::from_utf8(address)?;
+        let address = Address::from_str(address_string)?;
         return Ok(address);
     };
 
     if let VariableType::Private(UserInputValueType::Address(address)) = output {
-        let address = Address::from_str(&String::from_utf8(address.to_vec())?)?;
+        let address_string = std::str::from_utf8(address)?;
+        let address = Address::from_str(address_string)?;
         return Ok(address);
     };
 

--- a/src/lib/vm/mod.rs
+++ b/src/lib/vm/mod.rs
@@ -3,7 +3,7 @@ mod snarkvm;
 #[cfg(feature = "snarkvm_backend")]
 pub use self::snarkvm::*;
 
-#[cfg(feature = "vmtropy_backend")]
-mod vmtropy;
-#[cfg(feature = "vmtropy_backend")]
-pub use self::vmtropy::*;
+#[cfg(feature = "lambdavm_backend")]
+mod lambdavm;
+#[cfg(feature = "lambdavm_backend")]
+pub use self::lambdavm::*;

--- a/src/lib/vm/snarkvm/mod.rs
+++ b/src/lib/vm/snarkvm/mod.rs
@@ -41,7 +41,7 @@ pub type Deployment = snarkvm::prelude::Deployment<Testnet3>;
 pub type Transition = snarkvm::prelude::Transition<Testnet3>;
 
 /// These structs are nothing more than a wrapper around the actual IndexMap that is used
-/// for the verifying keys map. Why does it exist? The problem comes from the vmtropy backend.
+/// for the verifying keys map. Why does it exist? The problem comes from the lambdavm backend.
 /// Arkworks' verifying keys do not implement the regular `Serialize`/`Deserialize` traits,
 /// as they use their own custom `CanonicalSerialize`/`CanonicalDeserialize` ones. To implement
 /// the regular `Serialize`/`Deserialize` traits, we wrapped the IndexMap around this struct.

--- a/src/lib/vm/vmtropy/mod.rs
+++ b/src/lib/vm/vmtropy/mod.rs
@@ -3,32 +3,32 @@
 use std::str::FromStr;
 
 use anyhow::{anyhow, bail, ensure, Result};
+pub use lambdavm::build_program;
+pub use lambdavm::jaleo::{get_credits_key, mint_credits};
+pub use lambdavm::jaleo::{Itertools, UserInputValueType};
+use lambdavm::snarkvm::prelude::FromBytes;
+use lambdavm::VariableType;
 use log::debug;
 use sha3::{Digest, Sha3_256};
-pub use vmtropy::build_program;
-pub use vmtropy::jaleo::{get_credits_key, mint_credits};
-pub use vmtropy::jaleo::{Itertools, UserInputValueType};
-use vmtropy::snarkvm::prelude::FromBytes;
-use vmtropy::VariableType;
 
 const MAX_INPUTS: usize = 8;
 const MAX_OUTPUTS: usize = 8;
 
-pub type Address = vmtropy::jaleo::Address;
-pub type Identifier = vmtropy::jaleo::Identifier;
-pub type Program = vmtropy::jaleo::Program;
-pub type ProgramBuild = vmtropy::ProgramBuild;
-pub type Record = vmtropy::jaleo::Record;
-pub type EncryptedRecord = vmtropy::jaleo::EncryptedRecord;
-pub type ViewKey = vmtropy::jaleo::ViewKey;
-pub type PrivateKey = vmtropy::jaleo::PrivateKey;
-pub type Field = vmtropy::jaleo::Field;
-pub type ProgramID = vmtropy::jaleo::ProgramID;
-pub type VerifyingKey = vmtropy::jaleo::VerifyingKey;
-pub type ProvingKey = vmtropy::jaleo::ProvingKey;
-pub type Deployment = vmtropy::jaleo::Deployment;
-pub type Transition = vmtropy::jaleo::Transition;
-pub type VerifyingKeyMap = vmtropy::jaleo::VerifyingKeyMap;
+pub type Address = lambdavm::jaleo::Address;
+pub type Identifier = lambdavm::jaleo::Identifier;
+pub type Program = lambdavm::jaleo::Program;
+pub type ProgramBuild = lambdavm::ProgramBuild;
+pub type Record = lambdavm::jaleo::Record;
+pub type EncryptedRecord = lambdavm::jaleo::EncryptedRecord;
+pub type ViewKey = lambdavm::jaleo::ViewKey;
+pub type PrivateKey = lambdavm::jaleo::PrivateKey;
+pub type Field = lambdavm::jaleo::Field;
+pub type ProgramID = lambdavm::jaleo::ProgramID;
+pub type VerifyingKey = lambdavm::jaleo::VerifyingKey;
+pub type ProvingKey = lambdavm::jaleo::ProvingKey;
+pub type Deployment = lambdavm::jaleo::Deployment;
+pub type Transition = lambdavm::jaleo::Transition;
+pub type VerifyingKeyMap = lambdavm::jaleo::VerifyingKeyMap;
 
 /// Basic deployment validations
 pub fn verify_deployment(program: &Program, verifying_keys: VerifyingKeyMap) -> Result<()> {
@@ -138,20 +138,20 @@ pub fn verify_execution(
     let proof_bytes = hex::decode(&transition.proof)?;
 
     // TODO: Fix this by making proofs derive the deserialize trait instead of this.
-    let proof = vmtropy::jaleo::deserialize_proof(proof_bytes)?;
+    let proof = lambdavm::jaleo::deserialize_proof(proof_bytes)?;
 
     let inputs: Vec<UserInputValueType> = transition
         .inputs
         .iter()
         .filter_map(|i| match i {
-            vmtropy::VariableType::Public(value) => Some(value.clone()),
+            lambdavm::VariableType::Public(value) => Some(value.clone()),
             _ => None,
         })
         .collect();
 
     // Ensure the proof is valid.
     ensure!(
-        vmtropy::verify_proof(verifying_key.clone(), &inputs, &proof)?,
+        lambdavm::verify_proof(verifying_key.clone(), &inputs, &proof)?,
         "Transition is invalid"
     );
 
@@ -190,16 +190,17 @@ pub fn execution(
         .map_err(|e| anyhow!("{}", e))?;
 
     let (compiled_function_variables, proof) =
-        vmtropy::execute_function(&program, &function_name.to_string(), inputs)?;
+        lambdavm::execute_function(&program, &function_name.to_string(), inputs)?;
 
-    let inputs = vmtropy::jaleo::process_circuit_inputs(
+    let inputs = lambdavm::jaleo::process_circuit_inputs(
         &function,
         &compiled_function_variables,
         private_key,
     )?;
-    let outputs = vmtropy::jaleo::process_circuit_outputs(&function, &compiled_function_variables)?;
+    let outputs =
+        lambdavm::jaleo::process_circuit_outputs(&function, &compiled_function_variables)?;
 
-    let bytes_proof = vmtropy::jaleo::serialize_proof(proof)?;
+    let bytes_proof = lambdavm::jaleo::serialize_proof(proof)?;
     let encoded_proof = hex::encode(bytes_proof);
 
     let transition = Transition {

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -41,7 +41,7 @@ fn basic_program() {
     // get execution tx, assert expected output
     let transaction = retry_command(home_path, &["get", transaction_id]).unwrap();
 
-    #[cfg(feature = "vmtropy_backend")]
+    #[cfg(feature = "lambdavm_backend")]
     let pointer_path = "/Execution/transitions/0/outputs/0/Private";
     #[cfg(feature = "snarkvm_backend")]
     let pointer_path = "/Execution/transitions/0/outputs/0/value";
@@ -93,12 +93,12 @@ fn program_validations() {
 
     #[cfg(feature = "snarkvm_backend")]
     assert!(error.contains("does not exist"));
-    #[cfg(feature = "vmtropy_backend")]
+    #[cfg(feature = "lambdavm_backend")]
     assert!(error.contains("is not defined"));
 
     // fail on missing parameter
     let error = execute_program(home_path, &program_path, HELLO_PROGRAM, &["1u32"]).unwrap_err();
-    #[cfg(feature = "vmtropy_backend")]
+    #[cfg(feature = "lambdavm_backend")]
     assert!(error.contains("not assigned in registers"));
     #[cfg(feature = "snarkvm_backend")]
     assert!(error.contains("expects 2 inputs"));
@@ -131,7 +131,7 @@ fn decrypt_records() {
     let (owner, gates, amount) = get_decrypted_record(&transaction);
 
     cfg_if::cfg_if! {
-        if #[cfg(feature = "vmtropy_backend")] {
+        if #[cfg(feature = "lambdavm_backend")] {
             let expected_amount = "1u64";
             let expected_gates = "0u64";
             let expected_owner = address.to_string();
@@ -218,7 +218,7 @@ fn token_transaction() {
     let (owner, _gates, amount) = get_decrypted_record(&transaction);
 
     cfg_if::cfg_if! {
-        if #[cfg(feature = "vmtropy_backend")] {
+        if #[cfg(feature = "lambdavm_backend")] {
             assert_eq!(
                 owner,
                 format!("{}", alice_credentials.get("address").unwrap())
@@ -239,7 +239,7 @@ fn token_transaction() {
     let transaction = retry_command(_bob_home, &["get", transfer_transaction_id, "-d"]).unwrap();
     let (owner, _gates, amount) = get_decrypted_record(&transaction);
     cfg_if::cfg_if! {
-        if #[cfg(feature = "vmtropy_backend")] {
+        if #[cfg(feature = "lambdavm_backend")] {
             assert_eq!(
                 owner,
                 format!("{}", bob_credentials.get("address").unwrap())
@@ -348,8 +348,8 @@ fn try_create_credits() {
         &["100u64", "%account"],
     );
 
-    // TODO: When https://trello.com/c/3CM4OES2/78-make-sure-credits-are-not-being-minted-when-creating-executions is finished, this should return an error when using VMTropy
-    #[cfg(feature = "vmtropy_backend")]
+    // TODO: When https://trello.com/c/3CM4OES2/78-make-sure-credits-are-not-being-minted-when-creating-executions is finished, this should return an error when using lambdavm
+    #[cfg(feature = "lambdavm_backend")]
     output.unwrap();
     #[cfg(feature = "snarkvm_backend")]
     assert!(output
@@ -363,7 +363,7 @@ fn transfer_credits() {
     let validator_home = validator_account_path();
 
     // assuming the first record has more than 10 credits
-    #[cfg(feature = "vmtropy_backend")]
+    #[cfg(feature = "lambdavm_backend")]
     let record = client_command(&validator_home, &["account", "records"])
         .unwrap()
         .pointer("/1/ciphertext")
@@ -429,7 +429,7 @@ fn transaction_fees() {
         .unwrap()
         .to_string();
 
-    #[cfg(feature = "vmtropy_backend")]
+    #[cfg(feature = "lambdavm_backend")]
     let record = client_command(&validator_home, &["account", "records"])
         .unwrap()
         .pointer("/1/ciphertext")
@@ -497,7 +497,7 @@ fn transaction_fees() {
         .unwrap()
         .to_string();
 
-    #[cfg(feature = "vmtropy_backend")]
+    #[cfg(feature = "lambdavm_backend")]
     let record = client_command(receiver_home, &["account", "records"])
         .unwrap()
         .pointer("/0/ciphertext")
@@ -525,7 +525,7 @@ fn transaction_fees() {
         .unwrap()
         .to_string();
 
-    #[cfg(feature = "vmtropy_backend")]
+    #[cfg(feature = "lambdavm_backend")]
     let record = client_command(receiver_home, &["account", "records"])
         .unwrap()
         .pointer("/0/ciphertext")
@@ -586,7 +586,7 @@ fn staking() {
 
     #[cfg(feature = "snarkvm_backend")]
     let expected_subtraction_error = "Integer subtraction failed";
-    #[cfg(feature = "vmtropy_backend")]
+    #[cfg(feature = "lambdavm_backend")]
     let expected_subtraction_error = "Subtraction underflow";
 
     #[cfg(feature = "snarkvm_backend")]
@@ -598,7 +598,7 @@ fn staking() {
         .unwrap()
         .to_string();
 
-    #[cfg(feature = "vmtropy_backend")]
+    #[cfg(feature = "lambdavm_backend")]
     let record = client_command(&validator_home, &["account", "records"])
         .unwrap()
         .pointer("/2/ciphertext")
@@ -632,7 +632,7 @@ fn staking() {
         .unwrap()
         .to_string();
 
-    #[cfg(feature = "vmtropy_backend")]
+    #[cfg(feature = "lambdavm_backend")]
     let user_record = client_command(&receiver_home, &["account", "records"])
         .unwrap()
         .pointer("/0/ciphertext")
@@ -685,7 +685,7 @@ fn staking() {
         .unwrap()
         .to_string();
 
-    #[cfg(feature = "vmtropy_backend")]
+    #[cfg(feature = "lambdavm_backend")]
     let validator_record = client_command(&validator_home, &["account", "records"])
         .unwrap()
         .pointer("/0/ciphertext")
@@ -716,7 +716,7 @@ fn staking() {
         .as_str()
         .unwrap();
 
-    #[cfg(feature = "vmtropy_backend")]
+    #[cfg(feature = "lambdavm_backend")]
     let staked_credits_record = transaction
         .pointer("/Execution/transitions/0/outputs/1/EncryptedRecord/1/ciphertext")
         .unwrap()
@@ -853,7 +853,7 @@ fn get_encrypted_record(transaction: &serde_json::Value) -> &str {
     #[cfg(feature = "snarkvm_backend")]
     let pointer_path = "/Execution/transitions/0/outputs/0/value";
 
-    #[cfg(feature = "vmtropy_backend")]
+    #[cfg(feature = "lambdavm_backend")]
     let pointer_path = "/Execution/transitions/0/outputs/0/EncryptedRecord/1/ciphertext";
 
     transaction.pointer(pointer_path).unwrap().as_str().unwrap()


### PR DESCRIPTION
After [the PR for renaming VMTropy](https://github.com/lambdaclass/aleo_lambda_vm/pull/21), rename imports to use the corrrect name. 